### PR TITLE
Change 2 empty lines after imports to 1 for Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin requires `eslint`, `babel-eslint`, and the following other packages:
   - `eslint-plugin-import`
 
 ```shell
-$ npm install --save-dev 'acolorbright/eslint-config-acb-base#v4.0.0' babel-eslint@10.x eslint@6.x eslint-plugin-extra-rules@^0.8 eslint-plugin-import@2.x
+$ npm install --save-dev 'acolorbright/eslint-config-acb-base#v4.0.1' babel-eslint@10.x eslint@6.x eslint-plugin-extra-rules@^0.8 eslint-plugin-import@2.x
 ```
 
 Then add `"extends": "acb-base"` to your `.eslintrc` file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-acb-base",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "ACB's base JS ESLint config.",
   "main": "index.js",
   "scripts": {

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -6,7 +6,7 @@ module.exports = {
     'import',
   ],
   rules: {
-    'import/newline-after-import': ['error', { count: 2 }],
+    'import/newline-after-import': ['error', { count: 1 }],
     'import/order': ['error', {
       'newlines-between': 'always-and-inside-groups',
       groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],


### PR DESCRIPTION
[Sanjay pointed out](https://github.com/acolorbright/base/issues/12) that our ESLint config has a conflict with Prettier: in ESLint we specify that there must always be two empty lines after the final block of import statements, but Prettier always collapses multiple empty lines down to one.

[Jurriaan confirmed](https://github.com/prettier/prettier/issues/1610#issuecomment-302973179) that Prettier is not going to change its behaviour any time soon, so to continue to reap the benefits of Prettier without conflicts, I'm removing the requirement for 2 empty lines and changing it to 1.